### PR TITLE
Minio hotfixes

### DIFF
--- a/API/Middlewares/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/API/Middlewares/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Exceptions.Base;
+using Infrastructure.Services.Exceptions;
 
 namespace API.Middlewares.ExceptionHandler
 {
@@ -18,7 +19,7 @@ namespace API.Middlewares.ExceptionHandler
                     Message = $"{ex.Message}",
                     Code = 400
                 });
-                
+
                 logger.LogWarning(ex.Message + ex.StackTrace);
             }
             catch (NotPermittedException ex)
@@ -29,15 +30,25 @@ namespace API.Middlewares.ExceptionHandler
                     Message = ex.Message,
                     Code = 403
                 });
-                
+
                 logger.LogWarning(ex.Message + ex.StackTrace);
+            }
+            catch (ValueChangedException ex)
+            {
+                context.Response.StatusCode = 409;
+                
+                await context.Response.WriteAsJsonAsync(new ExceptionDetails
+                {
+                    Message = ex.Message,
+                    Code = 409
+                });
             }
             catch (BusinessException ex)
             {
                 context.Response.StatusCode = 500;
                 await context.Response.WriteAsJsonAsync(new ExceptionDetails
                 {
-                    Message = "Internal server error123" + ex.Message + "\n" + ex.StackTrace,
+                    Message = "Internal server error" + ex.Message,
                     Code = 500
                 });
                 
@@ -48,7 +59,7 @@ namespace API.Middlewares.ExceptionHandler
                 context.Response.StatusCode = 500;
                 await context.Response.WriteAsJsonAsync(new ExceptionDetails
                 {
-                    Message = "Internal server error123" + ex.Message + "\n" + ex.StackTrace,
+                    Message = "Internal server error" + ex.Message,
                     Code = 500
                 });
                 

--- a/Application/Cache/IMinioCache.cs
+++ b/Application/Cache/IMinioCache.cs
@@ -1,0 +1,9 @@
+﻿namespace Application.Cache;
+
+public interface IMinioCache
+{
+    Task RemoveAsync(string key);
+    Task<bool> ExistsAsync(string key);
+    Task SetStringAsync(string key, string value);
+    Task<string?> GetStringAsync(string key);
+}

--- a/Application/Exceptions/Base/ValueChangedException.cs
+++ b/Application/Exceptions/Base/ValueChangedException.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.Exceptions.Base;
+
+public class ValueChangedException(
+    string? message = "Пока вы редактировали ресурс, он изменился в другом процессе, повторите запрос еще раз" +
+                      "(обновите страницу) и посмотрите, не устраивает ли вас новое значение")
+    : Exception(message);

--- a/Application/Exceptions/ErrorMessages/UserCacheErrorMessages.cs
+++ b/Application/Exceptions/ErrorMessages/UserCacheErrorMessages.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Exceptions.ErrorMessages;
+
+public class UserCacheErrorMessages
+{
+    public const string AvatarChangedDuringRequest = "Аватар изменился во время вашего запроса, обновите страницу" +
+                                                     "и посмотрите не устраивает ли вас новое значение";
+}

--- a/Application/Services/Abstractions/IUserService.cs
+++ b/Application/Services/Abstractions/IUserService.cs
@@ -11,4 +11,5 @@ public interface IUserService
     public Task<List<UserReviewDto>> GetReviewsAsync(ReviewSearchDto dto);
     public Task<int> GetReviewsPagesCountAsync(ReviewSearchDto dto);
     public Task<List<FavouriteDto>> GetFavouritesAsync(long userId);
+    public Task<string> ConvertProfilePictureGuidToUrlAsync(string guid);
 }

--- a/Application/Services/Implementations/ReviewService.cs
+++ b/Application/Services/Implementations/ReviewService.cs
@@ -119,6 +119,11 @@ namespace Application.Services.Implementations
 				var picture = await minioCache.GetStringAsync(review.User.ProfilePictureUrl);
 				if (picture == null)
 				{
+					// это случай если картинка из oauth. тогда ее не кешируем и не преобразуем в url
+					if (review.User.ProfilePictureUrl.StartsWith("http"))
+					{
+						continue;
+					}
 					review.User.ProfilePictureUrl = await userService.ConvertProfilePictureGuidToUrlAsync(review.User.ProfilePictureUrl);
 					await minioCache.SetStringAsync(review.User.ProfilePictureUrl, review.User.ProfilePictureUrl);
 				}

--- a/DataAccess/Cache/MinioRedisCache.cs
+++ b/DataAccess/Cache/MinioRedisCache.cs
@@ -1,0 +1,49 @@
+﻿using Application.Cache;
+using Application.Exceptions.Base;
+using Application.Exceptions.ErrorMessages;
+using StackExchange.Redis;
+
+namespace DataAccess.Cache;
+
+public class MinioRedisCache: IMinioCache
+{
+    private IDatabase Database { get; }
+    
+    public MinioRedisCache(IDatabase database)
+    {
+        Database = database;
+    }
+
+    public async Task RemoveAsync(string key)
+    {
+        await Database.KeyDeleteAsync(key);
+    }
+
+    public async Task<bool> ExistsAsync(string key)
+    {
+        return await Database.KeyExistsAsync(key);
+    }
+
+    public async Task SetStringAsync(string key, string value)
+    {
+        var current = await Database.StringGetAsync(key);
+        
+        // может быть случай когда url в кеше поменялся после того как мы его получили
+        // если это действительно так, то отправим юзеру сообщение что он уже поменялся
+        var transaction = Database.CreateTransaction();
+        transaction.AddCondition(Condition.StringEqual(key, current));
+        _ = await transaction.StringSetAsync(key, value,TimeSpan.FromHours(1));
+        
+        var res = await transaction.ExecuteAsync();
+        
+        if (!res)
+        {
+            throw new ValueChangedException(UserCacheErrorMessages.AvatarChangedDuringRequest);
+        }
+    }
+
+    public async Task<string?> GetStringAsync(string key)
+    {
+        return await Database.StringGetAsync(key);
+    }
+}

--- a/DataAccess/DataAccess.csproj
+++ b/DataAccess/DataAccess.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frontend/src/Pages/ViewContent/ReviewItem.jsx
+++ b/Frontend/src/Pages/ViewContent/ReviewItem.jsx
@@ -15,6 +15,7 @@ import moderatorImg from "../../assets/moderator.svg";
 import crossImg from "../../assets/Cross.svg";
 import {moderatorService} from "../../services/moderator.service.js";
 import {adminUserService} from "../../services/admin.user.service.js";
+import defaultUserIcon from "../../assets/default.png"
 
 const modalStyles = {
     content: {
@@ -41,8 +42,11 @@ const ReviewItem = ({review, customStyles, notOpenModal}) => {
     const {setReviewsChanged} = useContext(ReviewsContext);
     const [modalOpen, setModalOpen] = useState(false)
     const [commentText, setCommentText] = useState('')
+    const [userIcon, setUserIcon] = useState(!review.user.avatar ? defaultUserIcon : review.user.avatar)
     const store = useDataStore()
-    
+    const setDefaultUserImg = () => {
+        setUserIcon(defaultUserIcon)
+    }
     const handleTextChange = (event) => {
         setCommentText(event.target.value)
     }
@@ -154,7 +158,7 @@ const ReviewItem = ({review, customStyles, notOpenModal}) => {
           <div className={styles.reviewItem} style={stylesCombined}>
               <div className={styles.reviewHeader}>
                   <div className={styles.userInfo}>
-                      {review.user.avatar && <img src={review.user.avatar} alt="" className={styles.avatar}/>}
+                      <img src={userIcon} alt="" className={styles.avatar} onError={setDefaultUserImg}/>
                       <span className={styles.username}>{review.user.name}</span>
                       <div className={styles.authorizedButtons}>
                           {authenticationService.isCurrentUserAdmin() &&

--- a/Infrastructure/Options/RedisOptions.cs
+++ b/Infrastructure/Options/RedisOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace Infrastructure.Options;
+
+public class RedisOptions
+{
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string Password { get; set; } = string.Empty;
+
+}

--- a/Infrastructure/Providers/Implementations/ProfilePicturesProvider.cs
+++ b/Infrastructure/Providers/Implementations/ProfilePicturesProvider.cs
@@ -23,11 +23,27 @@ public class ProfilePicturesProvider : IProfilePicturesProvider
 
     public async Task PutAsync(string name, Stream pictureStream, string contentType)
     {
+        // if bucket does not exist - create
+        
         var found = await _minioClient.BucketExistsAsync(new BucketExistsArgs().WithBucket(BucketName));
         if (!found)
         {
             await _minioClient.MakeBucketAsync(new MakeBucketArgs().WithBucket(BucketName));
         }
+        
+        // if obj exists - delete
+        
+        var stat = await _minioClient.StatObjectAsync(new StatObjectArgs()
+            .WithBucket(BucketName)
+            .WithObject(name));
+
+        if (stat is not null && !stat.DeleteMarker)
+        {
+            await _minioClient.RemoveObjectAsync(new RemoveObjectArgs()
+                .WithBucket(BucketName)
+                .WithObject(name));
+        }
+
 
         await _minioClient.PutObjectAsync(new PutObjectArgs()
             .WithBucket(BucketName)

--- a/Infrastructure/Providers/Implementations/ProfilePicturesProvider.cs
+++ b/Infrastructure/Providers/Implementations/ProfilePicturesProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Minio;
 using Minio.DataModel.Args;
+using Minio.Exceptions;
 
 namespace Infrastructure.Providers.Implementations;
 
@@ -24,34 +25,38 @@ public class ProfilePicturesProvider : IProfilePicturesProvider
     public async Task PutAsync(string name, Stream pictureStream, string contentType)
     {
         // if bucket does not exist - create
-        
+
         var found = await _minioClient.BucketExistsAsync(new BucketExistsArgs().WithBucket(BucketName));
         if (!found)
         {
             await _minioClient.MakeBucketAsync(new MakeBucketArgs().WithBucket(BucketName));
         }
-        
-        // if obj exists - delete
-        
-        var stat = await _minioClient.StatObjectAsync(new StatObjectArgs()
-            .WithBucket(BucketName)
-            .WithObject(name));
 
-        if (stat is not null && !stat.DeleteMarker)
+        // if obj exists - delete
+        try
         {
+            _ = await _minioClient.StatObjectAsync(new StatObjectArgs()
+                .WithBucket(BucketName)
+                .WithObject(name));
+
             await _minioClient.RemoveObjectAsync(new RemoveObjectArgs()
                 .WithBucket(BucketName)
                 .WithObject(name));
         }
+        catch (ObjectNotFoundException)
+        {
 
-
-        await _minioClient.PutObjectAsync(new PutObjectArgs()
-            .WithBucket(BucketName)
-            .WithObject(name)
-            .WithStreamData(pictureStream)
-            .WithObjectSize(pictureStream.Length)
-            .WithContentType(contentType)
-        );
+        }
+        finally
+        {
+            await _minioClient.PutObjectAsync(new PutObjectArgs()
+                .WithBucket(BucketName)
+                .WithObject(name)
+                .WithStreamData(pictureStream)
+                .WithObjectSize(pictureStream.Length)
+                .WithContentType(contentType)
+            );
+        }
     }
 
     public async Task<Stream> GetAsync(string name)

--- a/Infrastructure/Services/UserService.cs
+++ b/Infrastructure/Services/UserService.cs
@@ -112,4 +112,9 @@ public class UserService(
 
         return favouriteDtos;
     }
+
+    public Task<string> ConvertProfilePictureGuidToUrlAsync(string guid)
+    {
+        return profilePicturesProvider.GetUrlAsync(guid);
+    }
 }

--- a/Tests/ContentAPITests/ReviewServiceTests.cs
+++ b/Tests/ContentAPITests/ReviewServiceTests.cs
@@ -12,6 +12,7 @@ using Application.Services.Abstractions;
 using Application.Services.Implementations;
 using AutoMapper;
 using Infrastructure.Profiles;
+using Tests.Customizations;
 
 namespace Tests.ContentAPITests
 {
@@ -34,6 +35,8 @@ namespace Tests.ContentAPITests
                 mc.AddProfile(new ContentProfile());
             });
             _mapper = mappingConfig.CreateMapper();
+            _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            _fixture.Customizations.Add(new DateOnlySpecimenBuilder());
         }
 
         [Fact]
@@ -345,7 +348,6 @@ namespace Tests.ContentAPITests
 
         private List<Review> BuildDefaultReviewList() =>
             _fixture.Build<Review>()
-            .Without(u => u.User)
             .Without(u => u.Content)
             .Without(u => u.Comments)
             .Without(u => u.RatedByUsers)

--- a/Tests/ContentAPITests/ReviewServiceTests.cs
+++ b/Tests/ContentAPITests/ReviewServiceTests.cs
@@ -2,11 +2,13 @@
 using Domain.Entities;
 using Moq;
 using System.Linq.Expressions;
+using Application.Cache;
 using Application.Dto;
 using Application.Exceptions;
 using Application.Exceptions.ErrorMessages;
 using Application.Exceptions.Particular;
 using Application.Repositories;
+using Application.Services.Abstractions;
 using Application.Services.Implementations;
 using AutoMapper;
 using Infrastructure.Profiles;
@@ -19,6 +21,8 @@ namespace Tests.ContentAPITests
         private readonly Mock<IContentRepository> _mockContent = new();
         private readonly Mock<IUserRepository> _mockUser = new();
         private readonly Mock<IReviewRepository> _mockReview = new();
+        private readonly Mock<IMinioCache> _mockMinioCache = new();
+        private readonly Mock<IUserService> _mockUserService = new();
         private readonly IMapper _mapper;
         
         public ReviewServiceTests()
@@ -354,6 +358,8 @@ namespace Tests.ContentAPITests
                 _mockReview.Object, 
                 _mockContent.Object, 
                 _mockUser.Object, 
+                _mockMinioCache.Object,
+                _mockUserService.Object,
                 _mapper);
         
         private class ReviewDtoEqualityComparer : IEqualityComparer<ReviewDto>

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,6 +51,11 @@ services:
       - Minio:Port=${MINIO_PORT}
       - Minio:Endpoint=${MINIO_ENDPOINT}
         
+#      Redis
+      - Redis:Host=${REDIS_HOST}
+      - Redis:Port=${REDIS_PORT}
+      - Redis:Password=${REDIS_PASSWORD}
+        
 #      Jwt options
       - JwtOptions:Key=${JWT_SECRET}
       - JwtOptions:AccessTokenLifetimeInMinutes=${JWT_ACCESS_LIFETIME_MINUTES}
@@ -117,8 +122,13 @@ services:
   
   redis:
     image: redis
+    restart: always
     ports:
       - "6379:6379"
     volumes:
-      - ~/redis/data:/data
-    command: redis-server
+      - redis-data:/data
+    command: >
+      --requirepass ${REDIS_PASSWORD}
+volumes:
+    redis-data:
+      


### PR DESCRIPTION
добавил кеширование редис на запросы
раньше: каждая фотка юзеров отдельно получала presignedurl в minio. он следит за этими url и одинаковые фотки с разным временем получат один и тот же, но все равно идет обращение к минио ненужное.
сейчас: guid фотки и сам url кешируются в редисе. они весят немного, но ЗНАЧИТЕЛЬНО уменьшают обращения к серверу минио